### PR TITLE
Set up automated deployment

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -1,0 +1,28 @@
+version: 0.2
+
+env:
+  shell: bash
+  secrets-manager:
+    SLACK_WEBHOOKURL: "slack:k12stream"
+phases:
+  install:
+    commands:
+      - curl -L https://github.com/gohugoio/hugo/releases/download/v0.119.0/hugo_0.119.0_linux-amd64.tar.gz | tar -xvz
+      - chmod +x ./hugo
+      - export PATH=$PWD:$PATH
+  build:
+    commands:
+      - hugo -e $HUGO_ENVIRONMENT
+      - aws s3 cp --cache-control max-age=86400 --recursive public/ "s3://$CONTENT_S3_BUCKET/"
+      - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"
+    on-failure: ABORT
+    finally:
+      - "if [[ $CODEBUILD_BUILD_SUCCEEDING != 1 ]]; then curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"Error in raise-static-sites '\"$HUGO_ENVIRONMENT\"' pipeline!\"}' $SLACK_WEBHOOKURL; fi"
+  post_build:
+    commands:
+      - ls -R public/ > generated_files.txt
+      - export SLACK_MESSAGE="raise-static-sites $HUGO_ENVIRONMENT deployment completed for commit $COMMIT_ID"
+      - "curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"'\"$SLACK_MESSAGE\"'\"}' $SLACK_WEBHOOKURL"
+artifacts:
+  files:
+    - generated_files.txt


### PR DESCRIPTION
A note on this deployment: Since we don't expect a lot of velocity in this repo I went ahead and automated creating CloudFront invalidations as part of deployment. That will help us do any QA after merging changes (though we may need to clear browser caches which may otherwise cache for up to a day).